### PR TITLE
Multi-screen enhancement

### DIFF
--- a/calendar.lua
+++ b/calendar.lua
@@ -32,6 +32,7 @@ local tonumber = tonumber
 
 local awesome = awesome -- luacheck: ignore
 local awful = require("awful")
+local naughty = require("naughty")
 
 local calendar
 
@@ -41,6 +42,7 @@ if awful.widget.calendar_popup then
     widget:connect_signal(
       "mouse::enter",
       function ()
+        calendar:call_calendar(0, "tr", awful.screen.focused() )
         self:toggle()
     end)
     widget:connect_signal(

--- a/calendar.lua
+++ b/calendar.lua
@@ -24,7 +24,8 @@
   If used with Awesome Version < 4.2 it requires the `cal` program from
   `util-linux`, otherwise it will use the nicer awful.widget.calendar_popup
   Remember to `require` the widget **after** `beautiful.init` to ensure that
-  the widget's style matches the theme.  ]]
+   the widget's style matches the theme.  
+  ]]
 
 local os = os
 local string = string
@@ -32,7 +33,6 @@ local tonumber = tonumber
 
 local awesome = awesome -- luacheck: ignore
 local awful = require("awful")
-local naughty = require("naughty")
 
 local calendar
 


### PR DESCRIPTION
On a multi-head computer, the widget is always shown on the same screen (first one afaik). It should be shown on the same screen where the mouse is, since it's this screen the user is looking at.